### PR TITLE
Include a content security policy in a meta tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">


### PR DESCRIPTION
It's possible to use onHeadersReceived as shown in the Electron security
tutorial but setting a policy of "script-src 'self'" prevents displaying
the Developer Tools unless 'unsafe-eval' is part of the policy.