### PR TITLE
Correct production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "start": "yarn xpile && cross-env BROWSER=none DEV_URL=http://localhost:4349 PORT=4349 node start.js",
     "react-start": "cross-env PORT=4349 react-scripts start",
-    "react-build": "react-scripts build",
+    "react-build": "cross-env INLINE_RUNTIME_CHUNK=false react-scripts build",
     "electron-start": "wait-on http://localhost:4349 && electron .",
     "electron-build": "yarn xpile && electron-builder",
     "xpile": "tsc -p main",


### PR DESCRIPTION
By default, React builds a HTML file that contains inline script.  This
violates the "script-src 'self'" content security policy specified in
the meta tag.