### PR TITLE
Remove use of concurrently from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "build/electron.js",
   "private": true,
   "scripts": {
-    "build": "cross-env INLINE_RUNTIME_CHUNK=false concurrently \"react-scripts build\" \"npm run electron:build\"",
+    "build": "cross-env INLINE_RUNTIME_CHUNK=false react-scripts build && npm run electron:build",
     "test": "react-scripts test",
     "start": "npm run electron:build && cross-env DEV_URL=http://localhost:4349 concurrently \"tsc --project main -w\" \"npm run electron:start-web\" \"electronmon build/electron.js\"",
     "release": "npm run build && electron-builder --publish=never",


### PR DESCRIPTION
There's a race condition since the React build scripts recreate the output directory.