### PR TITLE
Stop all debugged processes upon application quit

### DIFF
--- a/app.njsproj
+++ b/app.njsproj
@@ -5,10 +5,10 @@
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <Name>app</Name>
     <RootNamespace>app</RootNamespace>
-    <NodeExePath>node_modules\electron\dist\electron.exe</NodeExePath>
     <SaveNodeJsSettingsInProjectFile>True</SaveNodeJsSettingsInProjectFile>
     <Environment>DEV_URL=http://localhost:4349
 IN_VISUAL_STUDIO=1</Environment>
+    <ScriptArguments>build/electron.js</ScriptArguments>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -16,7 +16,7 @@ IN_VISUAL_STUDIO=1</Environment>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>fb5105e7-8fc5-4db7-8487-ae22773af578</ProjectGuid>
     <ProjectHome>.</ProjectHome>
-    <StartupFile>build/electron.js</StartupFile>
+    <StartupFile>node_modules\electronmon\bin\cli.js</StartupFile>
     <StartWebBrowser>False</StartWebBrowser>
     <WorkingDirectory>.</WorkingDirectory>
     <OutputPath>.</OutputPath>

--- a/app.njsproj
+++ b/app.njsproj
@@ -6,9 +6,7 @@
     <Name>app</Name>
     <RootNamespace>app</RootNamespace>
     <SaveNodeJsSettingsInProjectFile>True</SaveNodeJsSettingsInProjectFile>
-    <Environment>DEV_URL=http://localhost:4349
-IN_VISUAL_STUDIO=1</Environment>
-    <ScriptArguments>build/electron.js</ScriptArguments>
+    <Environment>DEV_URL=http://localhost:4349</Environment>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -16,7 +14,7 @@ IN_VISUAL_STUDIO=1</Environment>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>fb5105e7-8fc5-4db7-8487-ae22773af578</ProjectGuid>
     <ProjectHome>.</ProjectHome>
-    <StartupFile>node_modules\electronmon\bin\cli.js</StartupFile>
+    <StartupFile>start.js</StartupFile>
     <StartWebBrowser>False</StartWebBrowser>
     <WorkingDirectory>.</WorkingDirectory>
     <OutputPath>.</OutputPath>

--- a/cra-typescript-electron.sln
+++ b/cra-typescript-electron.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		React.md = React.md
 		README.md = README.md
 		README.txt = README.txt
+		start.js = start.js
 		wait-for-web.js = wait-for-web.js
 	EndProjectSection
 EndProject

--- a/main/electron.ts
+++ b/main/electron.ts
@@ -122,13 +122,6 @@ app.on('window-all-closed', () => {
   // On OS X it's common for applications and their menu bar to stay active
   // until the user quits explicitly with Cmd+Q.
   if (process.platform !== 'darwin') {
-    if (child) {
-      if (process.platform === 'win32') {
-        spawnSync('taskkill', ['/f', '/pid', child.pid!.toString(), '/t']);
-      } else {
-        child.kill();
-      }
-    }
     app.quit();
   }
 });
@@ -138,5 +131,15 @@ app.on('activate', () => {
   // is clicked and there are no other windows open.
   if (!windows.length) {
     createWindow();
+  }
+});
+
+app.on('will-quit', () => {
+  if (child) {
+    if (process.platform === 'win32') {
+      spawnSync('taskkill', ['/f', '/pid', child.pid!.toString(), '/t']);
+    } else {
+      child.kill();
+    }
   }
 });

--- a/main/electron.ts
+++ b/main/electron.ts
@@ -91,13 +91,8 @@ function createWindow() {
   }
 }
 
-let child: ChildProcess;
-
 async function startApplication() {
   if (process.env.DEV_URL) {
-    if (process.env.IN_VISUAL_STUDIO) {
-      child = await runNpmAsync('spawn', 'electron:start-web');
-    }
     await runNpmAsync('exit', 'electron:wait-for-web');
   }
   createWindow();
@@ -131,15 +126,5 @@ app.on('activate', () => {
   // is clicked and there are no other windows open.
   if (!windows.length) {
     createWindow();
-  }
-});
-
-app.on('will-quit', () => {
-  if (child) {
-    if (process.platform === 'win32') {
-      spawnSync('taskkill', ['/f', '/pid', child.pid!.toString(), '/t']);
-    } else {
-      child.kill();
-    }
   }
 });

--- a/main/electron.ts
+++ b/main/electron.ts
@@ -128,3 +128,18 @@ app.on('activate', () => {
     createWindow();
   }
 });
+
+// Visual Studio starts a debugging session by running start.js, which sets the
+// START_PID environment variable.  On Windows, killing it with the /T flag
+// will stop all of the processes it started, including Electronmon and the
+// Web, ensuring a complete shut-down.
+const startPid = process.env['START_PID'];
+if (startPid) {
+  app.on('quit', () => {
+    if (process.platform === 'win32') {
+      spawnSync('taskkill', ['/F', '/PID', startPid, '/T']);
+    } else {
+      process.kill(Number(startPid));
+    }
+  });
+}

--- a/start.js
+++ b/start.js
@@ -1,0 +1,9 @@
+const { spawn } = require('child_process');
+
+const child = spawn('npm.cmd', ['start'], { shell: true });
+child.stdout.on('data', (arg) => {
+  console.log(arg.toString());
+});
+child.stderr.on('data', (arg) => {
+  console.error(arg.toString());
+});

--- a/start.js
+++ b/start.js
@@ -1,9 +1,12 @@
 const { spawn } = require('child_process');
 
+// Set the START_PID environment variable.  The application will use it to stop
+// a Visual Studio debugging session.
+process.env['START_PID'] = process.pid.toString();
 const child = spawn('npm.cmd', ['start'], { shell: true });
-child.stdout.on('data', (arg) => {
-  console.log(arg.toString());
+child.stdout.on('data', (buffer) => {
+  process.stdout.write(buffer);
 });
-child.stderr.on('data', (arg) => {
-  console.error(arg.toString());
+child.stderr.on('data', (buffer) => {
+  process.stderr.write(buffer);
 });


### PR DESCRIPTION
This will introduce a start-up script Visual Studio will use to debug
the application.  The application will kill it and all child processes
when it quits, ending the debugging session.