### PR TITLE
Distinguish between Electronmon and user action

### DIFF
--- a/main/api.ts
+++ b/main/api.ts
@@ -47,7 +47,7 @@ export function setActiveWindow(window: BrowserWindow) {
 
 export function startTimer() {
   if (!timerId) {
-    timerId = setInterval(() => activeWindow.webContents.send('main', new Date().toString()), 990);
+    timerId = setInterval(() => activeWindow.webContents.send('now', new Date().toString()), 990);
   }
 }
 

--- a/main/electron.ts
+++ b/main/electron.ts
@@ -137,12 +137,10 @@ app.on('activate', () => {
 const startPid = process.env['START_PID'];
 if (startPid) {
   let reloading = false;
-  process.on('message', (_message) => {
-    // Electronmon sends messages unrelated to restarting, such as "reload".
-    // Set a timer to ignore messages from Electronmon that don't result in a
-    // shut-down to distinguish them from quitting due to user action.
-    reloading = true;
-    setTimeout(() => reloading = false, 99);
+  process.on('message', (message) => {
+    if (message === 'reset') {
+      reloading = true;
+    }
   });
   app.on('quit', () => {
     if (!reloading) {

--- a/main/electron.ts
+++ b/main/electron.ts
@@ -132,14 +132,25 @@ app.on('activate', () => {
 // Visual Studio starts a debugging session by running start.js, which sets the
 // START_PID environment variable.  On Windows, killing it with the /T flag
 // will stop all of the processes it started, including Electronmon and the
-// Web, ensuring a complete shut-down.
+// Web, ensuring a complete shut-down.  Perform this process termination iff
+// quitting due to user action instead of Electronmon.
 const startPid = process.env['START_PID'];
 if (startPid) {
+  let reloading = false;
+  process.on('message', (_message) => {
+    // Electronmon sends messages unrelated to restarting, such as "reload".
+    // Set a timer to ignore messages from Electronmon that don't result in a
+    // shut-down to distinguish them from quitting due to user action.
+    reloading = true;
+    setTimeout(() => reloading = false, 99);
+  });
   app.on('quit', () => {
-    if (process.platform === 'win32') {
-      spawnSync('taskkill', ['/F', '/PID', startPid, '/T']);
-    } else {
-      process.kill(Number(startPid));
+    if (!reloading) {
+      if (process.platform === 'win32') {
+        spawnSync('taskkill', ['/F', '/PID', startPid, '/T']);
+      } else {
+        process.kill(Number(startPid));
+      }
     }
   });
 }

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -5,7 +5,7 @@ type ObserverFn = (message: string) => void;
 (() => {
   let messageHandler: ObserverFn = (_) => { };
 
-  ipcRenderer.on('main', (_event, message: string) => {
+  ipcRenderer.on('now', (_event, message: string) => {
     // Do not include the event since it includes the sender.
     messageHandler(message);
   });

--- a/start.js
+++ b/start.js
@@ -3,7 +3,7 @@ const { spawn } = require('child_process');
 // Set the START_PID environment variable.  The application will use it to stop
 // a Visual Studio debugging session.
 process.env['START_PID'] = process.pid.toString();
-const child = spawn('npm.cmd', ['start'], { shell: true });
+const child = spawn(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['start'], { shell: true });
 child.stdout.on('data', (buffer) => {
   process.stdout.write(buffer);
 });


### PR DESCRIPTION
Shut-down might occur as a result of Electronmon detecting a file change or the user quitting the application. This will distinguish between the two and terminate all processes, including Electronmon, only in the latter case.